### PR TITLE
Fix AtomRenderer which fails to flush response.

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/atom/AtomRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/atom/AtomRenderer.groovy
@@ -107,6 +107,7 @@ class AtomRenderer<T> extends HalXmlRenderer<T> {
                 }
             }
             writer.end()
+            context.writer.flush()
         } else {
             throw new IllegalArgumentException("Cannot render object [$object] using Atom. The AtomRenderer can only be used with domain classes that specify 'dateCreated' and 'lastUpdated' properties")
         }


### PR DESCRIPTION
Problem: Atom rendering is broken. Because it never flushes the response (like HalJsonRenderer does) grails defaults to searching for the appropriate GSP / JSP pages which it can't find, and throws a 500 error saying so.

Steps to replicate:
- grails create-app myapp
- do following as per http://grails.github.io/grails-doc/latest/guide/webServices.html#atom
  *\* Add domain class with title, lastUpdated and dateCreated properties annotated with @Resource(uri='/foo',formats=['atom','json'])
  *\* Add AtomRenderer and AtomCollectionRenderer into resources.groovy
- grails run-app
- create a resource e.g. curl -i -X POST -H 'Accept:application/json; Content-type: application/json' -d '{ "title":"...", "lastUpdated":"...", "dateCreated":"..." }' http://localhost:8080/myapp/foo
- response is 201 created, with header 'Location: http://localhost:8080/myapp/foo/1
- lookup the resource in atom e.g. curl -i -X POST -H 'Accept:application/json; Content-type: application/json' -d '{ "title":"...", "lastUpdated":"...", "dateCreated":"..." }' http://localhost:8080/myapp/foo/1
- response 500 error reporting exception (paraphrased) "cannot find view.jsp"

Solution: make AtomRenderer flush the response.
